### PR TITLE
세팅창 구성 완료

### DIFF
--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -1,3 +1,4 @@
+// lib/screens/settings_screen.dart
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -19,29 +20,41 @@ class SettingsScreen extends StatelessWidget {
           ],
         ),
       ),
-      body: Center(
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          width: 200,
-          height: 120,
-          decoration: BoxDecoration(
-            color: const Color(0xFFA8A090),
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: const Center(
-            child: Text(
-              '공사중..',
-              style: TextStyle(
-                color: Colors.black,
-                fontSize: 18,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
+
+      // ───────────────── Body: 라운드 박스 2개 ─────────────────
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            _buildSectionCard([
+              _buildSettingItem(Icons.language, '언어'),
+              _buildSettingItem(Icons.dark_mode, '다크 모드'),
+              _buildSettingItem(Icons.interests, '관심 키워드 설정'),
+              _buildSettingItem(Icons.notifications, '알림 설정'),
+              _buildSettingItem(Icons.delete_sweep, '캐시 삭제'),
+            ]),
+
+            const SizedBox(height: 16),
+
+            _buildSectionCard([
+              _buildSettingItem(Icons.privacy_tip, '약관 및 개인정보 처리 동의', () {
+                _showDialog(context, '약관 및 개인정보 처리 동의', '''
+앱을 이용함으로써 사용자님은 본 서비스의 이용약관 및 개인정보 수집·이용에 동의하게 됩니다. 수집된 정보는 더 나은 서비스 제공을 위해 활용됩니다. 
+자세한 사항은 고객센터 또는 홈페이지를 참고해주세요.
+''');
+              }),
+              _buildSettingItem(Icons.shield, '개인정보 처리방침', () {
+                _showDialog(context, '개인정보 처리방침', '''
+우리는 사용자 개인정보를 소중히 보호하며, 수집한 정보는 오직 서비스 제공 목적에 한해서만 사용됩니다. 
+본 방침은 관련 법령에 따라 변경될 수 있으며, 최신 내용은 앱 내에서 확인 가능합니다.
+''');
+              }),
+            ]),
+          ],
         ),
       ),
 
-      // 하단 네비게이션 바
+      // ───────────────── Bottom Navigation (그대로) ─────────────────
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.fixed,
         backgroundColor: Colors.black,
@@ -74,6 +87,91 @@ class SettingsScreen extends StatelessWidget {
           BottomNavigationBarItem(icon: Icon(Icons.video_library_rounded), label: '영상'),
           BottomNavigationBarItem(icon: Icon(Icons.chat_bubble_outline_rounded), label: '대화'),
           BottomNavigationBarItem(icon: Icon(Icons.settings_rounded), label: '설정'),
+        ],
+      ),
+    );
+  }
+
+  // ───────────────── Helpers ─────────────────
+
+  // 라운드 박스 컨테이너
+  Widget _buildSectionCard(List<Widget> children) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      decoration: BoxDecoration(
+        color: const Color(0xFFA8A090),
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: const [
+          BoxShadow(
+            color: Colors.white24, // 밝은 그림자
+            blurRadius: 6,
+            offset: Offset(0, 3),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          for (int i = 0; i < children.length; i++) ...[
+            children[i],
+            if (i != children.length - 1)
+              const Divider(height: 1, thickness: 1, color: Colors.black26),
+          ],
+        ],
+      ),
+    );
+  }
+
+  // 개별 설정 아이템 (리플 포함)
+  Widget _buildSettingItem(IconData icon, String title, [VoidCallback? onTap]) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+          child: Row(
+            children: [
+              Icon(icon, color: Colors.black87),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  title,
+                  style: const TextStyle(
+                    color: Colors.black87,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              if (onTap != null)
+                const Icon(Icons.chevron_right, color: Colors.black54),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // 다이얼로그
+  static void _showDialog(BuildContext context, String title, String body) {
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF1B1B1B),
+        title: Text(
+          title,
+          style: const TextStyle(color: Colors.white),
+        ),
+        content: Text(
+          body,
+          style: const TextStyle(color: Colors.white70, height: 1.4),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('확인'),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
SettingsScreen 추가

라운드 박스 2개로 UI 구성
일반 설정 항목: 언어, 다크 모드, 관심 키워드 설정, 알림 설정, 캐시 삭제
약관 관련 항목: 약관 및 개인정보 처리 동의, 개인정보 처리방침

각 항목을 _buildSettingItem으로 분리하여 재사용 가능하게 구현
약관/개인정보 처리 항목에 다이얼로그 표시 기능 추가
라운드 박스에 boxShadow 적용 → 검정 배경에서도 입체감 표현